### PR TITLE
Sync theme transition and persistence across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,19 +9,21 @@
   
       
     :root {
-      --bg-color: #f4f9ff;
-      --text-color: #222;
+      --bg-color: #fff6eb;
+      --text-color: #2b2622;
       --card-bg: #ffffff;
-      --card-border: #dbe5ff;
-      --accent: #0f62fe;
-      --accent-alt: #6f52ed;
-      --hover-glow: rgba(111, 82, 237, 0.2);
-      --button-text: #fff;
-      --glow-1: rgba(111, 82, 237, 0.35);
-      --glow-2: rgba(15, 98, 254, 0.35);
-      --glow-3: rgba(0, 195, 255, 0.25);
-      --grid-line: rgba(111, 82, 237, 0.12);
-      --overlay-color: rgba(255, 255, 255, 0.55);
+      --card-border: #f2d7b8;
+      --accent: #ff7a59;
+      --accent-alt: #ffb347;
+      --hover-glow: rgba(255, 158, 106, 0.25);
+      --button-text: #fff7f0;
+      --glow-1: rgba(255, 200, 160, 0.35);
+      --glow-2: rgba(255, 170, 120, 0.35);
+      --glow-3: rgba(255, 235, 190, 0.25);
+      --grid-line: rgba(255, 200, 160, 0.16);
+      --overlay-color: rgba(255, 244, 230, 0.65);
+      --theme-shift-duration: 1.35s;
+      --motion-duration: 16s;
     }
 
     body.dark-mode {
@@ -65,6 +67,80 @@
                   radial-gradient(circle at 80% 30%, rgba(111, 82, 237, 0.12), transparent 60%),
                   radial-gradient(circle at 50% 80%, rgba(0, 195, 255, 0.08), transparent 65%),
                   #05070f;
+      opacity: 1;
+      transition: opacity var(--theme-shift-duration) ease-in-out,
+                  filter var(--theme-shift-duration) ease-in-out,
+                  background 0.6s ease;
+      will-change: opacity, filter;
+    }
+
+    body:not(.dark-mode) #particle-canvas {
+      opacity: 0;
+      filter: blur(22px) saturate(1.25);
+      background: transparent;
+    }
+
+    body.theme-transition #particle-canvas,
+    body.theme-transition .wave-background {
+      transition-duration: var(--theme-shift-duration);
+    }
+
+    .wave-background {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: -5;
+      overflow: hidden;
+      opacity: 0;
+      transition: opacity var(--theme-shift-duration) ease-in-out,
+                  transform var(--theme-shift-duration) ease-in-out,
+                  filter var(--theme-shift-duration) ease-in-out;
+      transform: scale(1.05);
+      filter: blur(4px);
+    }
+
+    .wave-background::before,
+    .wave-background::after {
+      content: "";
+      position: absolute;
+      width: 160%;
+      height: 160%;
+      top: -30%;
+      left: -30%;
+      opacity: 0.95;
+      transition: opacity 0.6s ease-in-out;
+    }
+
+    .wave-background::before {
+      background:
+        radial-gradient(circle at 18% 35%, rgba(255, 162, 120, 0.7) 0%, rgba(255, 162, 120, 0) 60%),
+        radial-gradient(circle at 72% 28%, rgba(255, 194, 140, 0.75) 0%, rgba(255, 194, 140, 0) 62%),
+        linear-gradient(130deg, rgba(255, 126, 89, 0.75), rgba(255, 197, 120, 0.85), rgba(255, 239, 189, 0.7));
+      background-size: 140% 140%, 150% 150%, 200% 200%;
+      filter: blur(32px);
+      animation: waveFlow var(--motion-duration) ease-in-out infinite;
+    }
+
+    .wave-background::after {
+      background:
+        radial-gradient(circle at 15% 25%, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0) 55%),
+        radial-gradient(circle at 65% 40%, rgba(255, 224, 189, 0.55) 0%, rgba(255, 224, 189, 0) 60%),
+        radial-gradient(circle at 35% 70%, rgba(255, 213, 160, 0.5) 0%, rgba(255, 213, 160, 0) 58%),
+        radial-gradient(circle at 80% 80%, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0) 62%);
+      background-size: 120% 120%, 130% 130%, 110% 110%, 140% 140%;
+      mix-blend-mode: screen;
+      filter: blur(12px);
+      opacity: 0.8;
+      animation: bubbleFloat var(--motion-duration) ease-in-out infinite;
+    }
+
+    body:not(.dark-mode) .wave-background {
+      opacity: 1;
+      transform: scale(1);
+      filter: blur(0px);
     }
 
     .background-overlay {
@@ -82,9 +158,9 @@
     }
 
     body:not(.dark-mode) .background-overlay {
-      mix-blend-mode: multiply;
-      background: linear-gradient(135deg, var(--overlay-color), rgba(220, 230, 255, 0.35));
-      opacity: 0.7;
+      mix-blend-mode: screen;
+      background: linear-gradient(135deg, rgba(255, 250, 240, 0.55), rgba(255, 204, 153, 0.35));
+      opacity: 0.6;
     }
 
     body::before,
@@ -254,6 +330,36 @@
       }
     }
 
+    @keyframes waveFlow {
+      0% {
+        background-position: 0% 50%, 10% 40%, 0% 50%;
+        transform: translate3d(-2%, -2%, 0) rotate(0deg);
+      }
+      50% {
+        background-position: 100% 60%, 80% 65%, 110% 60%;
+        transform: translate3d(3%, 3%, 0) rotate(1.8deg);
+      }
+      100% {
+        background-position: 0% 50%, 10% 40%, 0% 50%;
+        transform: translate3d(-2%, -1%, 0) rotate(0deg);
+      }
+    }
+
+    @keyframes bubbleFloat {
+      0% {
+        background-position: 0% 0%, 20% 40%, 30% 70%, 60% 80%;
+        transform: translate3d(1%, 1%, 0) scale(1.02);
+      }
+      50% {
+        background-position: 80% 60%, 100% 80%, 70% 20%, 0% 40%;
+        transform: translate3d(-2%, -1%, 0) scale(1.06);
+      }
+      100% {
+        background-position: 0% 0%, 20% 40%, 30% 70%, 60% 80%;
+        transform: translate3d(1%, 1%, 0) scale(1.02);
+      }
+    }
+
     @media (max-width: 768px) {
       .projects {
         flex-direction: column;
@@ -267,8 +373,20 @@
     }
   </style>
 </head>
-<body class="dark-mode">
-
+<body>
+  <script>
+    (function () {
+      try {
+        const storedTheme = localStorage.getItem('preferred-theme');
+        if (storedTheme === 'dark' || storedTheme === null) {
+          document.body.classList.add('dark-mode');
+        }
+      } catch (error) {
+        document.body.classList.add('dark-mode');
+      }
+    })();
+  </script>
+  <div class="wave-background"></div>
   <canvas id="particle-canvas"></canvas>
   <div class="background-overlay"></div>
 
@@ -352,9 +470,62 @@
 </section>
 
   <script>
-    function toggleTheme() {
-      document.body.classList.toggle('dark-mode');
+    const rootStyles = getComputedStyle(document.documentElement);
+    const themeShiftDuration = parseFloat(rootStyles.getPropertyValue('--theme-shift-duration')) * 1000 || 1350;
+    const motionDurationSeconds = parseFloat(rootStyles.getPropertyValue('--motion-duration')) || 16;
+    const THEME_STORAGE_KEY = 'preferred-theme';
+    let themeTransitionTimeout;
+
+    function applyTheme(mode, options = {}) {
+      const { skipTransition = false } = options;
+      const enableTransition = !skipTransition;
+
+      if (enableTransition) {
+        document.body.classList.add('theme-transition');
+        clearTimeout(themeTransitionTimeout);
+      } else {
+        document.body.classList.remove('theme-transition');
+      }
+
+      document.body.classList.toggle('dark-mode', mode === 'dark');
+
+      if (enableTransition) {
+        themeTransitionTimeout = setTimeout(() => {
+          document.body.classList.remove('theme-transition');
+        }, themeShiftDuration);
+      }
+
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, mode);
+      } catch (error) {
+        /* localStorage might be unavailable */
+      }
     }
+
+    function toggleTheme() {
+      const newMode = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+      applyTheme(newMode);
+    }
+
+    (function initialiseTheme() {
+      let storedTheme;
+      try {
+        storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+      } catch (error) {
+        storedTheme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+      }
+
+      if (storedTheme === 'dark' || storedTheme === 'light') {
+        applyTheme(storedTheme, { skipTransition: true });
+      } else {
+        const defaultMode = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+        try {
+          localStorage.setItem(THEME_STORAGE_KEY, defaultMode);
+        } catch (error) {
+          /* ignore */
+        }
+      }
+    })();
 
     (function () {
       const canvas = document.getElementById('particle-canvas');
@@ -363,10 +534,10 @@
       const ctx = canvas.getContext('2d');
       const particles = [];
       const config = {
-        maxDistance: 160,
-        baseSpeed: 0.08,
+        maxDistance: 150 * (motionDurationSeconds / 16),
+        baseSpeed: 0.18 * (16 / motionDurationSeconds),
         density: 0.00012,
-        size: [1.2, 2.8]
+        size: [1.2, 2.6]
       };
 
       let width = 0;

--- a/seemore.html
+++ b/seemore.html
@@ -6,21 +6,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    /* COPY YOUR ENTIRE CSS FROM index.html */
+  
+      
     :root {
-      --bg-color: #f4f9ff;
-      --text-color: #222;
+      --bg-color: #fff6eb;
+      --text-color: #2b2622;
       --card-bg: #ffffff;
-      --card-border: #dbe5ff;
-      --accent: #0f62fe;
-      --accent-alt: #6f52ed;
-      --hover-glow: rgba(111, 82, 237, 0.2);
-      --button-text: #fff;
-      --glow-1: rgba(111, 82, 237, 0.35);
-      --glow-2: rgba(15, 98, 254, 0.35);
-      --glow-3: rgba(0, 195, 255, 0.25);
-      --grid-line: rgba(111, 82, 237, 0.12);
-      --overlay-color: rgba(255, 255, 255, 0.55);
+      --card-border: #f2d7b8;
+      --accent: #ff7a59;
+      --accent-alt: #ffb347;
+      --hover-glow: rgba(255, 158, 106, 0.25);
+      --button-text: #fff7f0;
+      --glow-1: rgba(255, 200, 160, 0.35);
+      --glow-2: rgba(255, 170, 120, 0.35);
+      --glow-3: rgba(255, 235, 190, 0.25);
+      --grid-line: rgba(255, 200, 160, 0.16);
+      --overlay-color: rgba(255, 244, 230, 0.65);
+      --theme-shift-duration: 1.35s;
+      --motion-duration: 16s;
     }
 
     body.dark-mode {
@@ -64,6 +67,80 @@
                   radial-gradient(circle at 80% 30%, rgba(111, 82, 237, 0.12), transparent 60%),
                   radial-gradient(circle at 50% 80%, rgba(0, 195, 255, 0.08), transparent 65%),
                   #05070f;
+      opacity: 1;
+      transition: opacity var(--theme-shift-duration) ease-in-out,
+                  filter var(--theme-shift-duration) ease-in-out,
+                  background 0.6s ease;
+      will-change: opacity, filter;
+    }
+
+    body:not(.dark-mode) #particle-canvas {
+      opacity: 0;
+      filter: blur(22px) saturate(1.25);
+      background: transparent;
+    }
+
+    body.theme-transition #particle-canvas,
+    body.theme-transition .wave-background {
+      transition-duration: var(--theme-shift-duration);
+    }
+
+    .wave-background {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: -5;
+      overflow: hidden;
+      opacity: 0;
+      transition: opacity var(--theme-shift-duration) ease-in-out,
+                  transform var(--theme-shift-duration) ease-in-out,
+                  filter var(--theme-shift-duration) ease-in-out;
+      transform: scale(1.05);
+      filter: blur(4px);
+    }
+
+    .wave-background::before,
+    .wave-background::after {
+      content: "";
+      position: absolute;
+      width: 160%;
+      height: 160%;
+      top: -30%;
+      left: -30%;
+      opacity: 0.95;
+      transition: opacity 0.6s ease-in-out;
+    }
+
+    .wave-background::before {
+      background:
+        radial-gradient(circle at 18% 35%, rgba(255, 162, 120, 0.7) 0%, rgba(255, 162, 120, 0) 60%),
+        radial-gradient(circle at 72% 28%, rgba(255, 194, 140, 0.75) 0%, rgba(255, 194, 140, 0) 62%),
+        linear-gradient(130deg, rgba(255, 126, 89, 0.75), rgba(255, 197, 120, 0.85), rgba(255, 239, 189, 0.7));
+      background-size: 140% 140%, 150% 150%, 200% 200%;
+      filter: blur(32px);
+      animation: waveFlow var(--motion-duration) ease-in-out infinite;
+    }
+
+    .wave-background::after {
+      background:
+        radial-gradient(circle at 15% 25%, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0) 55%),
+        radial-gradient(circle at 65% 40%, rgba(255, 224, 189, 0.55) 0%, rgba(255, 224, 189, 0) 60%),
+        radial-gradient(circle at 35% 70%, rgba(255, 213, 160, 0.5) 0%, rgba(255, 213, 160, 0) 58%),
+        radial-gradient(circle at 80% 80%, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0) 62%);
+      background-size: 120% 120%, 130% 130%, 110% 110%, 140% 140%;
+      mix-blend-mode: screen;
+      filter: blur(12px);
+      opacity: 0.8;
+      animation: bubbleFloat var(--motion-duration) ease-in-out infinite;
+    }
+
+    body:not(.dark-mode) .wave-background {
+      opacity: 1;
+      transform: scale(1);
+      filter: blur(0px);
     }
 
     .background-overlay {
@@ -81,9 +158,9 @@
     }
 
     body:not(.dark-mode) .background-overlay {
-      mix-blend-mode: multiply;
-      background: linear-gradient(135deg, var(--overlay-color), rgba(220, 230, 255, 0.35));
-      opacity: 0.7;
+      mix-blend-mode: screen;
+      background: linear-gradient(135deg, rgba(255, 250, 240, 0.55), rgba(255, 204, 153, 0.35));
+      opacity: 0.6;
     }
 
     body::before,
@@ -253,6 +330,36 @@
       }
     }
 
+    @keyframes waveFlow {
+      0% {
+        background-position: 0% 50%, 10% 40%, 0% 50%;
+        transform: translate3d(-2%, -2%, 0) rotate(0deg);
+      }
+      50% {
+        background-position: 100% 60%, 80% 65%, 110% 60%;
+        transform: translate3d(3%, 3%, 0) rotate(1.8deg);
+      }
+      100% {
+        background-position: 0% 50%, 10% 40%, 0% 50%;
+        transform: translate3d(-2%, -1%, 0) rotate(0deg);
+      }
+    }
+
+    @keyframes bubbleFloat {
+      0% {
+        background-position: 0% 0%, 20% 40%, 30% 70%, 60% 80%;
+        transform: translate3d(1%, 1%, 0) scale(1.02);
+      }
+      50% {
+        background-position: 80% 60%, 100% 80%, 70% 20%, 0% 40%;
+        transform: translate3d(-2%, -1%, 0) scale(1.06);
+      }
+      100% {
+        background-position: 0% 0%, 20% 40%, 30% 70%, 60% 80%;
+        transform: translate3d(1%, 1%, 0) scale(1.02);
+      }
+    }
+
     @media (max-width: 768px) {
       .projects {
         flex-direction: column;
@@ -266,8 +373,20 @@
     }
   </style>
 </head>
-<body class="dark-mode">
-
+<body>
+  <script>
+    (function () {
+      try {
+        const storedTheme = localStorage.getItem('preferred-theme');
+        if (storedTheme === 'dark' || storedTheme === null) {
+          document.body.classList.add('dark-mode');
+        }
+      } catch (error) {
+        document.body.classList.add('dark-mode');
+      }
+    })();
+  </script>
+  <div class="wave-background"></div>
   <canvas id="particle-canvas"></canvas>
   <div class="background-overlay"></div>
 
@@ -353,9 +472,62 @@
   </div>
 
   <script>
-    function toggleTheme() {
-      document.body.classList.toggle('dark-mode');
+    const rootStyles = getComputedStyle(document.documentElement);
+    const themeShiftDuration = parseFloat(rootStyles.getPropertyValue('--theme-shift-duration')) * 1000 || 1350;
+    const motionDurationSeconds = parseFloat(rootStyles.getPropertyValue('--motion-duration')) || 16;
+    const THEME_STORAGE_KEY = 'preferred-theme';
+    let themeTransitionTimeout;
+
+    function applyTheme(mode, options = {}) {
+      const { skipTransition = false } = options;
+      const enableTransition = !skipTransition;
+
+      if (enableTransition) {
+        document.body.classList.add('theme-transition');
+        clearTimeout(themeTransitionTimeout);
+      } else {
+        document.body.classList.remove('theme-transition');
+      }
+
+      document.body.classList.toggle('dark-mode', mode === 'dark');
+
+      if (enableTransition) {
+        themeTransitionTimeout = setTimeout(() => {
+          document.body.classList.remove('theme-transition');
+        }, themeShiftDuration);
+      }
+
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, mode);
+      } catch (error) {
+        /* localStorage might be unavailable */
+      }
     }
+
+    function toggleTheme() {
+      const newMode = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+      applyTheme(newMode);
+    }
+
+    (function initialiseTheme() {
+      let storedTheme;
+      try {
+        storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+      } catch (error) {
+        storedTheme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+      }
+
+      if (storedTheme === 'dark' || storedTheme === 'light') {
+        applyTheme(storedTheme, { skipTransition: true });
+      } else {
+        const defaultMode = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+        try {
+          localStorage.setItem(THEME_STORAGE_KEY, defaultMode);
+        } catch (error) {
+          /* ignore */
+        }
+      }
+    })();
 
     (function () {
       const canvas = document.getElementById('particle-canvas');
@@ -364,10 +536,10 @@
       const ctx = canvas.getContext('2d');
       const particles = [];
       const config = {
-        maxDistance: 160,
-        baseSpeed: 0.08,
+        maxDistance: 150 * (motionDurationSeconds / 16),
+        baseSpeed: 0.18 * (16 / motionDurationSeconds),
         density: 0.00012,
-        size: [1.2, 2.8]
+        size: [1.2, 2.6]
       };
 
       let width = 0;


### PR DESCRIPTION
## Summary
- persist the visitor's theme choice with localStorage and reapply it without extra transitions on load
- mirror the starfield and warm wave visuals on the see more page so both views share the same theming
- reuse the synchronized animation timing values across pages so toggling feels consistent everywhere

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd797ce94832ba288dde449f1ed6a