### PR TITLE
Revamp light mode experience and update theme styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,16 @@
       --aurora-blue: rgba(46, 128, 210, 0.38);
       --aurora-violet: rgba(55, 94, 188, 0.32);
       --surface-glow: rgba(79, 216, 194, 0.2);
+      --button-bg-1: rgba(255, 184, 138, 0.92);
+      --button-bg-2: rgba(255, 104, 138, 0.9);
+      --button-outline: rgba(255, 255, 255, 0.28);
+      --button-shadow: rgba(0, 0, 0, 0.45);
+      --button-hover-shadow: rgba(0, 0, 0, 0.6);
+      --button-hover-glow: rgba(255, 140, 120, 0.48);
+      --light-gradient-1: #ffe6c8;
+      --light-gradient-2: #ffc2a1;
+      --light-gradient-3: #ff8d90;
+      --light-gradient-highlight: rgba(255, 243, 228, 0.55);
     }
 
     body.dark-mode {
@@ -62,6 +72,17 @@
       --aurora-blue: rgba(52, 168, 255, 0.36);
       --aurora-violet: rgba(62, 110, 214, 0.3);
       --surface-glow: rgba(112, 255, 234, 0.24);
+      --button-outline: rgba(112, 255, 234, 0.3);
+      --button-shadow: rgba(0, 0, 0, 0.55);
+      --button-hover-shadow: rgba(0, 0, 0, 0.65);
+      --button-hover-glow: rgba(96, 240, 220, 0.4);
+    }
+
+    body.light-mode {
+      --button-outline: rgba(255, 142, 108, 0.3);
+      --button-shadow: rgba(226, 106, 74, 0.25);
+      --button-hover-shadow: rgba(226, 106, 74, 0.35);
+      --button-hover-glow: rgba(255, 183, 140, 0.5);
     }
 
     body {
@@ -78,6 +99,88 @@
       scroll-behavior: smooth;
     }
 
+    .light-background {
+      position: fixed;
+      inset: 0;
+      overflow: hidden;
+      pointer-events: none;
+      z-index: -7;
+      opacity: 0;
+      transition: opacity var(--theme-shift-duration) ease;
+      background: radial-gradient(120% 120% at 20% 80%, rgba(255, 198, 152, 0.45) 0%, rgba(255, 128, 128, 0.12) 52%, rgba(255, 128, 128, 0));
+    }
+
+    .light-gradient {
+      position: absolute;
+      inset: -15% -20% -10% -20%;
+      background:
+        radial-gradient(120% 120% at 18% 90%, rgba(255, 232, 205, 0.9) 0%, rgba(255, 166, 116, 0.5) 42%, rgba(255, 126, 139, 0.08) 72%),
+        radial-gradient(120% 110% at 82% 10%, rgba(255, 200, 178, 0.75) 0%, rgba(255, 128, 140, 0.16) 58%, rgba(255, 128, 140, 0));
+      background-color: var(--light-gradient-2);
+      mix-blend-mode: screen;
+      filter: saturate(1.12);
+      animation: lightGradientFlow 28s ease-in-out infinite alternate;
+      will-change: transform;
+    }
+
+    .light-gradient::before,
+    .light-gradient::after {
+      content: "";
+      position: absolute;
+      inset: -30% -10% -40% -20%;
+      background-repeat: no-repeat;
+      mix-blend-mode: screen;
+      opacity: 0.65;
+    }
+
+    .light-gradient::before {
+      background-image:
+        radial-gradient(120% 110% at 50% 110%, rgba(255, 255, 255, 0.55) 0%, rgba(255, 165, 132, 0.08) 68%, rgba(255, 165, 132, 0)),
+        radial-gradient(120% 120% at 20% -10%, rgba(255, 188, 160, 0.45) 0%, rgba(255, 131, 145, 0.08) 65%, rgba(255, 131, 145, 0));
+      animation: lightGradientDrift 32s ease-in-out infinite;
+    }
+
+    .light-gradient::after {
+      inset: -40% -20% -20% -10%;
+      background-image:
+        conic-gradient(from 140deg at 40% 55%, rgba(255, 255, 255, 0.32), rgba(255, 167, 127, 0.08), rgba(255, 255, 255, 0.36), rgba(255, 167, 127, 0.08));
+      filter: blur(80px);
+      opacity: 0.55;
+      animation: lightGradientPulse 24s ease-in-out infinite alternate;
+    }
+
+    .light-bubbles {
+      position: absolute;
+      inset: 0;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    .light-bubble {
+      position: absolute;
+      bottom: -22vmin;
+      left: 50%;
+      width: var(--size);
+      height: var(--size);
+      margin-left: calc(var(--left-offset) - 50%);
+      background: radial-gradient(circle at 30% 35%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 205, 178, 0.55) 42%, rgba(255, 120, 130, 0.0) 72%);
+      border-radius: 50%;
+      filter: blur(0.2vmin);
+      opacity: 0;
+      animation: bubbleRise var(--duration) linear infinite;
+      animation-delay: var(--delay);
+      will-change: transform, opacity;
+    }
+
+    .light-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 25% 35% 35% 25%;
+      border-radius: 50%;
+      background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0));
+      opacity: 0.7;
+    }
+
     #particle-canvas,
     #aurora-canvas {
       position: fixed;
@@ -90,11 +193,11 @@
     }
 
     #aurora-canvas {
-      z-index: -7;
+      z-index: -6;
     }
 
     #particle-canvas {
-      z-index: -6;
+      z-index: -5;
     }
 
     .static-background-layer {
@@ -115,14 +218,14 @@
     }
 
     .static-background-layer.static-light {
-      background: linear-gradient(140deg, #081926 0%, #0f2434 48%, #07131e 100%);
+      background: linear-gradient(140deg, #fff0d9 0%, #ffc9a9 45%, #ff8d90 100%);
     }
 
     .static-background-layer.static-light::after {
       background-image:
-        radial-gradient(circle at 15% 85%, rgba(90, 180, 255, 0.18) 0%, transparent 55%),
-        radial-gradient(circle at 78% 20%, rgba(90, 220, 200, 0.16) 0%, transparent 60%);
-      opacity: 0.6;
+        radial-gradient(circle at 15% 80%, rgba(255, 204, 170, 0.28) 0%, transparent 55%),
+        radial-gradient(circle at 78% 20%, rgba(255, 158, 158, 0.2) 0%, transparent 60%);
+      opacity: 0.55;
     }
 
     .static-background-layer.static-dark {
@@ -133,7 +236,7 @@
       position: fixed;
       inset: 0;
       pointer-events: none;
-      z-index: -5;
+      z-index: -4;
       background:
         radial-gradient(circle at 18% 18%, rgba(90, 226, 205, 0.2), transparent 55%),
         radial-gradient(circle at 82% 22%, rgba(88, 163, 255, 0.18), transparent 60%),
@@ -144,8 +247,12 @@
     }
 
     body.light-mode .background-overlay {
-      filter: saturate(1.15);
-      opacity: 0.7;
+      background:
+        radial-gradient(circle at 20% 80%, rgba(255, 204, 170, 0.45), transparent 58%),
+        radial-gradient(circle at 78% 15%, rgba(255, 160, 178, 0.36), transparent 62%),
+        linear-gradient(140deg, rgba(255, 226, 198, 0.55), rgba(255, 160, 160, 0.3));
+      filter: saturate(1.08);
+      opacity: 0.6;
     }
 
     body.dark-mode .background-overlay {
@@ -158,7 +265,7 @@
       position: fixed;
       inset: 0;
       pointer-events: none;
-      z-index: -4;
+      z-index: -3;
       transition: opacity 0.6s ease, filter 0.6s ease;
     }
 
@@ -171,7 +278,7 @@
     }
 
     body::after {
-      z-index: -3;
+      z-index: -2;
       background-image:
         repeating-linear-gradient(to right, var(--grid-line), var(--grid-line) 1px, transparent 1px, transparent 70px),
         repeating-linear-gradient(to bottom, var(--grid-line), var(--grid-line) 1px, transparent 1px, transparent 70px);
@@ -179,24 +286,46 @@
       animation: driftGrid 32s linear infinite;
     }
 
-    body.light-mode #particle-canvas {
-      opacity: 0.85;
-      filter: saturate(1.05) brightness(1.02);
+    body.light-mode #particle-canvas,
+    body.light-mode #aurora-canvas {
+      opacity: 0;
+      filter: saturate(1);
     }
 
     body.dark-mode #particle-canvas {
       opacity: 1;
-      filter: saturate(1.25);
-    }
-
-    body.light-mode #aurora-canvas {
-      opacity: 0.9;
-      filter: hue-rotate(-4deg) saturate(1.05);
+      filter: saturate(1.2);
     }
 
     body.dark-mode #aurora-canvas {
       opacity: 1;
       filter: saturate(1.2);
+    }
+
+    body.light-mode .light-background {
+      opacity: 1;
+    }
+
+    body.dark-mode .light-background {
+      opacity: 0;
+    }
+
+    body.dark-mode .light-bubble {
+      animation-play-state: paused;
+    }
+
+    body.light-mode .light-bubble {
+      animation-play-state: running;
+    }
+
+    body.static-background .light-background {
+      opacity: 0;
+    }
+
+    body.static-background .light-gradient,
+    body.static-background .light-gradient::before,
+    body.static-background .light-gradient::after {
+      animation: none !important;
     }
 
     body.theme-transition #particle-canvas,
@@ -262,26 +391,27 @@
       top: 20px;
       right: 20px;
       cursor: pointer;
-      font-size: 1rem;
-      padding: 10px 18px;
+      font-size: 0.95rem;
+      padding: 10px 22px;
       border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.22);
+      border: 1px solid var(--button-outline);
       color: var(--button-text);
-      background: linear-gradient(135deg, rgba(92, 247, 214, 0.85), rgba(98, 173, 255, 0.8));
+      background: linear-gradient(135deg, var(--button-bg-1), var(--button-bg-2));
       box-shadow:
-        0 0 14px var(--surface-glow),
-        0 10px 28px rgba(0, 0, 0, 0.45);
-      transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-      letter-spacing: 0.05em;
+        0 0 16px rgba(255, 180, 150, 0.28),
+        0 12px 28px var(--button-shadow);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease, opacity 0.3s ease;
     }
 
     .theme-toggle:hover,
     .theme-toggle:focus-visible {
       transform: translateY(-2px);
       box-shadow:
-        0 0 26px var(--hover-glow),
-        0 18px 40px rgba(0, 0, 0, 0.55);
-      filter: brightness(1.1);
+        0 0 32px var(--button-hover-glow),
+        0 18px 42px var(--button-hover-shadow);
+      filter: brightness(1.05);
       outline: none;
     }
 
@@ -381,17 +511,19 @@
       align-items: center;
       justify-content: center;
       gap: 8px;
-      padding: 12px 28px;
+      padding: 12px 30px;
       border-radius: 999px;
       font-weight: 600;
       text-decoration: none;
       color: var(--button-text);
-      background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+      background: linear-gradient(135deg, var(--button-bg-1), var(--button-bg-2));
+      border: 1px solid var(--button-outline);
       box-shadow:
-        0 0 18px var(--surface-glow),
-        0 16px 32px rgba(0, 0, 0, 0.45);
-      transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-      letter-spacing: 0.04em;
+        0 0 22px rgba(255, 180, 150, 0.28),
+        0 16px 32px var(--button-shadow);
+      transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease, opacity 0.3s ease;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
 
     .see-more a:hover,
@@ -400,9 +532,9 @@
     .cta-button:focus-visible {
       transform: translateY(-3px);
       box-shadow:
-        0 0 30px var(--hover-glow),
-        0 22px 46px rgba(0, 0, 0, 0.58);
-      filter: brightness(1.1);
+        0 0 38px var(--button-hover-glow),
+        0 22px 48px var(--button-hover-shadow);
+      filter: brightness(1.05);
       outline: none;
     }
 
@@ -427,6 +559,62 @@
       margin-top: 20px;
     }
 
+    @keyframes lightGradientFlow {
+      0% {
+        transform: translate3d(-3%, 1%, 0) scale(1.02);
+      }
+      50% {
+        transform: translate3d(3%, -2%, 0) scale(1.05);
+      }
+      100% {
+        transform: translate3d(-2%, 2%, 0) scale(1.01);
+      }
+    }
+
+    @keyframes lightGradientDrift {
+      0% {
+        transform: translate3d(2%, -2%, 0) rotate(-1deg) scale(1.05);
+      }
+      50% {
+        transform: translate3d(-3%, 3%, 0) rotate(1deg) scale(1.08);
+      }
+      100% {
+        transform: translate3d(3%, -1%, 0) rotate(-0.5deg) scale(1.03);
+      }
+    }
+
+    @keyframes lightGradientPulse {
+      0% {
+        opacity: 0.4;
+        transform: rotate(-4deg) scale(1.05);
+      }
+      50% {
+        opacity: 0.65;
+        transform: rotate(4deg) scale(1.08);
+      }
+      100% {
+        opacity: 0.45;
+        transform: rotate(-2deg) scale(1.02);
+      }
+    }
+
+    @keyframes bubbleRise {
+      0% {
+        transform: translate3d(0, 0, 0) scale(0.85);
+        opacity: 0;
+      }
+      15% {
+        opacity: 0.7;
+      }
+      60% {
+        opacity: 0.95;
+      }
+      100% {
+        transform: translate3d(var(--drift, 0), -120vh, 0) scale(1.08);
+        opacity: 0;
+      }
+    }
+
     @keyframes floatGlow {
       0% {
         transform: translate3d(0, 0, 0) scale(1);
@@ -449,6 +637,19 @@
     }
 
     @media (max-width: 768px) {
+      .light-gradient {
+        inset: -22% -28% -18% -28%;
+        animation-duration: 32s;
+      }
+
+      .light-gradient::after {
+        filter: blur(70px);
+      }
+
+      .light-bubble {
+        filter: blur(0.15vmin);
+      }
+
       .projects {
         flex-direction: column;
         align-items: center;
@@ -480,6 +681,11 @@
 </head>
 <body class="dark-mode">
 
+  <div class="light-background">
+    <div class="light-gradient"></div>
+    <div class="light-bubbles"></div>
+  </div>
+
   <canvas id="aurora-canvas"></canvas>
   <canvas id="particle-canvas"></canvas>
   <div class="static-background-layer static-light"></div>
@@ -490,7 +696,7 @@
     <h1>Sander Schulman</h1>
     <p class="intro">
 Mechanical Engineer exploring AI architecture and innovative engineering solutions, with passions in music and entrepreneurship. Explore a selection of my work below.    </p>
-    <button class="theme-toggle" type="button">☀️ / 🌙</button>
+    <button class="theme-toggle" type="button">Toggle Theme</button>
   </header>
 
   <section class="project-section">
@@ -599,6 +805,43 @@ Mechanical Engineer exploring AI architecture and innovative engineering solutio
 
     applyInitialTheme();
 
+    const bubbleContainer = document.querySelector('.light-bubbles');
+    const bubbleMediaQuery = window.matchMedia('(max-width: 768px)');
+
+    function populateBubbles() {
+      if (!bubbleContainer || staticMode) return;
+      bubbleContainer.innerHTML = '';
+      const isMobile = bubbleMediaQuery.matches;
+      const bubbleTotal = isMobile ? 18 : 36;
+
+      for (let i = 0; i < bubbleTotal; i++) {
+        const bubble = document.createElement('span');
+        bubble.className = 'light-bubble';
+        const size = (isMobile ? 4 : 5) + Math.random() * (isMobile ? 5 : 9);
+        const duration = (isMobile ? 20 : 28) + Math.random() * (isMobile ? 8 : 12);
+        const delay = -Math.random() * duration;
+        const horizontal = Math.random() * 100;
+        const driftRange = isMobile ? 12 : 20;
+        const drift = (Math.random() * driftRange - driftRange / 2).toFixed(2);
+
+        bubble.style.setProperty('--size', `${size}vmin`);
+        bubble.style.setProperty('--duration', `${duration}s`);
+        bubble.style.setProperty('--delay', `${delay}s`);
+        bubble.style.setProperty('--left-offset', `${horizontal}%`);
+        bubble.style.setProperty('--drift', `${drift}vw`);
+        bubbleContainer.appendChild(bubble);
+      }
+    }
+
+    if (bubbleContainer && !staticMode) {
+      populateBubbles();
+      if (typeof bubbleMediaQuery.addEventListener === 'function') {
+        bubbleMediaQuery.addEventListener('change', populateBubbles);
+      } else if (typeof bubbleMediaQuery.addListener === 'function') {
+        bubbleMediaQuery.addListener(populateBubbles);
+      }
+    }
+
     const toggleButton = document.querySelector('.theme-toggle');
     if (toggleButton) {
       toggleButton.addEventListener('click', () => toggleTheme(true));
@@ -649,23 +892,27 @@ Mechanical Engineer exploring AI architecture and innovative engineering solutio
 
       document.addEventListener('themechange', (event) => {
         updateThemeStyles(event.detail?.theme);
+        pausedForLight = currentTheme !== 'dark';
+        if (!pausedForLight) {
+          clearedForLight = false;
+        }
       });
 
       const baseConfig = {
         maxDistance: 170,
-        baseSpeed: 0.16,
-        density: 0.00006,
-        size: [1.0, 2.2],
-        maxCount: 110,
-        maxConnections: 5
+        baseSpeed: 0.14,
+        density: 0.000045,
+        size: [0.9, 2.1],
+        maxCount: 95,
+        maxConnections: 4
       };
 
       const mobileConfig = {
         maxDistance: 135,
-        baseSpeed: 0.11,
-        density: 0.000028,
-        size: [0.9, 1.8],
-        maxCount: 60,
+        baseSpeed: 0.1,
+        density: 0.000022,
+        size: [0.8, 1.7],
+        maxCount: 45,
         maxConnections: 3
       };
 
@@ -674,6 +921,8 @@ Mechanical Engineer exploring AI architecture and innovative engineering solutio
       let dpr = window.devicePixelRatio || 1;
       let currentConfig = { ...baseConfig };
       let connectionCounts = new Uint8Array(0);
+      let pausedForLight = currentTheme !== 'dark';
+      let clearedForLight = pausedForLight;
 
       function updateConfig() {
         currentConfig = mobileQuery.matches ? { ...mobileConfig } : { ...baseConfig };
@@ -809,6 +1058,16 @@ Mechanical Engineer exploring AI architecture and innovative engineering solutio
         lastTimestamp = timestamp;
         const deltaMultiplier = deltaTime / (1000 / 60);
 
+        if (pausedForLight) {
+          if (!clearedForLight) {
+            ctx.clearRect(0, 0, width, height);
+            clearedForLight = true;
+          }
+          requestAnimationFrame(animate);
+          return;
+        }
+
+        clearedForLight = false;
         ctx.clearRect(0, 0, width, height);
         connectionCounts.fill(0);
         particles.forEach((particle) => {

--- a/seemore.html
+++ b/seemore.html
@@ -34,6 +34,16 @@
       --aurora-blue: rgba(46, 128, 210, 0.38);
       --aurora-violet: rgba(55, 94, 188, 0.32);
       --surface-glow: rgba(79, 216, 194, 0.2);
+      --button-bg-1: rgba(255, 184, 138, 0.92);
+      --button-bg-2: rgba(255, 104, 138, 0.9);
+      --button-outline: rgba(255, 255, 255, 0.28);
+      --button-shadow: rgba(0, 0, 0, 0.45);
+      --button-hover-shadow: rgba(0, 0, 0, 0.6);
+      --button-hover-glow: rgba(255, 140, 120, 0.48);
+      --light-gradient-1: #ffe6c8;
+      --light-gradient-2: #ffc2a1;
+      --light-gradient-3: #ff8d90;
+      --light-gradient-highlight: rgba(255, 243, 228, 0.55);
     }
 
     body.dark-mode {
@@ -62,6 +72,17 @@
       --aurora-blue: rgba(52, 168, 255, 0.36);
       --aurora-violet: rgba(62, 110, 214, 0.3);
       --surface-glow: rgba(112, 255, 234, 0.24);
+      --button-outline: rgba(112, 255, 234, 0.3);
+      --button-shadow: rgba(0, 0, 0, 0.55);
+      --button-hover-shadow: rgba(0, 0, 0, 0.65);
+      --button-hover-glow: rgba(96, 240, 220, 0.4);
+    }
+
+    body.light-mode {
+      --button-outline: rgba(255, 142, 108, 0.3);
+      --button-shadow: rgba(226, 106, 74, 0.25);
+      --button-hover-shadow: rgba(226, 106, 74, 0.35);
+      --button-hover-glow: rgba(255, 183, 140, 0.5);
     }
 
     body {
@@ -78,6 +99,88 @@
       scroll-behavior: smooth;
     }
 
+    .light-background {
+      position: fixed;
+      inset: 0;
+      overflow: hidden;
+      pointer-events: none;
+      z-index: -7;
+      opacity: 0;
+      transition: opacity var(--theme-shift-duration) ease;
+      background: radial-gradient(120% 120% at 20% 80%, rgba(255, 198, 152, 0.45) 0%, rgba(255, 128, 128, 0.12) 52%, rgba(255, 128, 128, 0));
+    }
+
+    .light-gradient {
+      position: absolute;
+      inset: -15% -20% -10% -20%;
+      background:
+        radial-gradient(120% 120% at 18% 90%, rgba(255, 232, 205, 0.9) 0%, rgba(255, 166, 116, 0.5) 42%, rgba(255, 126, 139, 0.08) 72%),
+        radial-gradient(120% 110% at 82% 10%, rgba(255, 200, 178, 0.75) 0%, rgba(255, 128, 140, 0.16) 58%, rgba(255, 128, 140, 0));
+      background-color: var(--light-gradient-2);
+      mix-blend-mode: screen;
+      filter: saturate(1.12);
+      animation: lightGradientFlow 28s ease-in-out infinite alternate;
+      will-change: transform;
+    }
+
+    .light-gradient::before,
+    .light-gradient::after {
+      content: "";
+      position: absolute;
+      inset: -30% -10% -40% -20%;
+      background-repeat: no-repeat;
+      mix-blend-mode: screen;
+      opacity: 0.65;
+    }
+
+    .light-gradient::before {
+      background-image:
+        radial-gradient(120% 110% at 50% 110%, rgba(255, 255, 255, 0.55) 0%, rgba(255, 165, 132, 0.08) 68%, rgba(255, 165, 132, 0)),
+        radial-gradient(120% 120% at 20% -10%, rgba(255, 188, 160, 0.45) 0%, rgba(255, 131, 145, 0.08) 65%, rgba(255, 131, 145, 0));
+      animation: lightGradientDrift 32s ease-in-out infinite;
+    }
+
+    .light-gradient::after {
+      inset: -40% -20% -20% -10%;
+      background-image:
+        conic-gradient(from 140deg at 40% 55%, rgba(255, 255, 255, 0.32), rgba(255, 167, 127, 0.08), rgba(255, 255, 255, 0.36), rgba(255, 167, 127, 0.08));
+      filter: blur(80px);
+      opacity: 0.55;
+      animation: lightGradientPulse 24s ease-in-out infinite alternate;
+    }
+
+    .light-bubbles {
+      position: absolute;
+      inset: 0;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    .light-bubble {
+      position: absolute;
+      bottom: -22vmin;
+      left: 50%;
+      width: var(--size);
+      height: var(--size);
+      margin-left: calc(var(--left-offset) - 50%);
+      background: radial-gradient(circle at 30% 35%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 205, 178, 0.55) 42%, rgba(255, 120, 130, 0.0) 72%);
+      border-radius: 50%;
+      filter: blur(0.2vmin);
+      opacity: 0;
+      animation: bubbleRise var(--duration) linear infinite;
+      animation-delay: var(--delay);
+      will-change: transform, opacity;
+    }
+
+    .light-bubble::after {
+      content: "";
+      position: absolute;
+      inset: 25% 35% 35% 25%;
+      border-radius: 50%;
+      background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0));
+      opacity: 0.7;
+    }
+
     #particle-canvas,
     #aurora-canvas {
       position: fixed;
@@ -90,11 +193,11 @@
     }
 
     #aurora-canvas {
-      z-index: -7;
+      z-index: -6;
     }
 
     #particle-canvas {
-      z-index: -6;
+      z-index: -5;
     }
 
     .static-background-layer {
@@ -115,14 +218,14 @@
     }
 
     .static-background-layer.static-light {
-      background: linear-gradient(140deg, #081926 0%, #0f2434 48%, #07131e 100%);
+      background: linear-gradient(140deg, #fff0d9 0%, #ffc9a9 45%, #ff8d90 100%);
     }
 
     .static-background-layer.static-light::after {
       background-image:
-        radial-gradient(circle at 15% 85%, rgba(90, 180, 255, 0.18) 0%, transparent 55%),
-        radial-gradient(circle at 78% 20%, rgba(90, 220, 200, 0.16) 0%, transparent 60%);
-      opacity: 0.6;
+        radial-gradient(circle at 15% 80%, rgba(255, 204, 170, 0.28) 0%, transparent 55%),
+        radial-gradient(circle at 78% 20%, rgba(255, 158, 158, 0.2) 0%, transparent 60%);
+      opacity: 0.55;
     }
 
     .static-background-layer.static-dark {
@@ -133,7 +236,7 @@
       position: fixed;
       inset: 0;
       pointer-events: none;
-      z-index: -5;
+      z-index: -4;
       background:
         radial-gradient(circle at 18% 18%, rgba(90, 226, 205, 0.2), transparent 55%),
         radial-gradient(circle at 82% 22%, rgba(88, 163, 255, 0.18), transparent 60%),
@@ -144,8 +247,12 @@
     }
 
     body.light-mode .background-overlay {
-      filter: saturate(1.15);
-      opacity: 0.7;
+      background:
+        radial-gradient(circle at 20% 80%, rgba(255, 204, 170, 0.45), transparent 58%),
+        radial-gradient(circle at 78% 15%, rgba(255, 160, 178, 0.36), transparent 62%),
+        linear-gradient(140deg, rgba(255, 226, 198, 0.55), rgba(255, 160, 160, 0.3));
+      filter: saturate(1.08);
+      opacity: 0.6;
     }
 
     body.dark-mode .background-overlay {
@@ -158,7 +265,7 @@
       position: fixed;
       inset: 0;
       pointer-events: none;
-      z-index: -4;
+      z-index: -3;
       transition: opacity 0.6s ease, filter 0.6s ease;
     }
 
@@ -171,7 +278,7 @@
     }
 
     body::after {
-      z-index: -3;
+      z-index: -2;
       background-image:
         repeating-linear-gradient(to right, var(--grid-line), var(--grid-line) 1px, transparent 1px, transparent 70px),
         repeating-linear-gradient(to bottom, var(--grid-line), var(--grid-line) 1px, transparent 1px, transparent 70px);
@@ -179,24 +286,46 @@
       animation: driftGrid 32s linear infinite;
     }
 
-    body.light-mode #particle-canvas {
-      opacity: 0.85;
-      filter: saturate(1.05) brightness(1.02);
+    body.light-mode #particle-canvas,
+    body.light-mode #aurora-canvas {
+      opacity: 0;
+      filter: saturate(1);
     }
 
     body.dark-mode #particle-canvas {
       opacity: 1;
-      filter: saturate(1.25);
-    }
-
-    body.light-mode #aurora-canvas {
-      opacity: 0.9;
-      filter: hue-rotate(-4deg) saturate(1.05);
+      filter: saturate(1.2);
     }
 
     body.dark-mode #aurora-canvas {
       opacity: 1;
       filter: saturate(1.2);
+    }
+
+    body.light-mode .light-background {
+      opacity: 1;
+    }
+
+    body.dark-mode .light-background {
+      opacity: 0;
+    }
+
+    body.dark-mode .light-bubble {
+      animation-play-state: paused;
+    }
+
+    body.light-mode .light-bubble {
+      animation-play-state: running;
+    }
+
+    body.static-background .light-background {
+      opacity: 0;
+    }
+
+    body.static-background .light-gradient,
+    body.static-background .light-gradient::before,
+    body.static-background .light-gradient::after {
+      animation: none !important;
     }
 
     body.theme-transition #particle-canvas,
@@ -262,26 +391,27 @@
       top: 20px;
       right: 20px;
       cursor: pointer;
-      font-size: 1rem;
-      padding: 10px 18px;
+      font-size: 0.95rem;
+      padding: 10px 22px;
       border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.22);
+      border: 1px solid var(--button-outline);
       color: var(--button-text);
-      background: linear-gradient(135deg, rgba(92, 247, 214, 0.85), rgba(98, 173, 255, 0.8));
+      background: linear-gradient(135deg, var(--button-bg-1), var(--button-bg-2));
       box-shadow:
-        0 0 14px var(--surface-glow),
-        0 10px 28px rgba(0, 0, 0, 0.45);
-      transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-      letter-spacing: 0.05em;
+        0 0 16px rgba(255, 180, 150, 0.28),
+        0 12px 28px var(--button-shadow);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease, opacity 0.3s ease;
     }
 
     .theme-toggle:hover,
     .theme-toggle:focus-visible {
       transform: translateY(-2px);
       box-shadow:
-        0 0 26px var(--hover-glow),
-        0 18px 40px rgba(0, 0, 0, 0.55);
-      filter: brightness(1.1);
+        0 0 32px var(--button-hover-glow),
+        0 18px 42px var(--button-hover-shadow);
+      filter: brightness(1.05);
       outline: none;
     }
 
@@ -381,17 +511,19 @@
       align-items: center;
       justify-content: center;
       gap: 8px;
-      padding: 12px 28px;
+      padding: 12px 30px;
       border-radius: 999px;
       font-weight: 600;
       text-decoration: none;
       color: var(--button-text);
-      background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+      background: linear-gradient(135deg, var(--button-bg-1), var(--button-bg-2));
+      border: 1px solid var(--button-outline);
       box-shadow:
-        0 0 18px var(--surface-glow),
-        0 16px 32px rgba(0, 0, 0, 0.45);
-      transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-      letter-spacing: 0.04em;
+        0 0 22px rgba(255, 180, 150, 0.28),
+        0 16px 32px var(--button-shadow);
+      transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease, opacity 0.3s ease;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
 
     .see-more a:hover,
@@ -400,9 +532,9 @@
     .cta-button:focus-visible {
       transform: translateY(-3px);
       box-shadow:
-        0 0 30px var(--hover-glow),
-        0 22px 46px rgba(0, 0, 0, 0.58);
-      filter: brightness(1.1);
+        0 0 38px var(--button-hover-glow),
+        0 22px 48px var(--button-hover-shadow);
+      filter: brightness(1.05);
       outline: none;
     }
 
@@ -427,6 +559,62 @@
       margin-top: 20px;
     }
 
+    @keyframes lightGradientFlow {
+      0% {
+        transform: translate3d(-3%, 1%, 0) scale(1.02);
+      }
+      50% {
+        transform: translate3d(3%, -2%, 0) scale(1.05);
+      }
+      100% {
+        transform: translate3d(-2%, 2%, 0) scale(1.01);
+      }
+    }
+
+    @keyframes lightGradientDrift {
+      0% {
+        transform: translate3d(2%, -2%, 0) rotate(-1deg) scale(1.05);
+      }
+      50% {
+        transform: translate3d(-3%, 3%, 0) rotate(1deg) scale(1.08);
+      }
+      100% {
+        transform: translate3d(3%, -1%, 0) rotate(-0.5deg) scale(1.03);
+      }
+    }
+
+    @keyframes lightGradientPulse {
+      0% {
+        opacity: 0.4;
+        transform: rotate(-4deg) scale(1.05);
+      }
+      50% {
+        opacity: 0.65;
+        transform: rotate(4deg) scale(1.08);
+      }
+      100% {
+        opacity: 0.45;
+        transform: rotate(-2deg) scale(1.02);
+      }
+    }
+
+    @keyframes bubbleRise {
+      0% {
+        transform: translate3d(0, 0, 0) scale(0.85);
+        opacity: 0;
+      }
+      15% {
+        opacity: 0.7;
+      }
+      60% {
+        opacity: 0.95;
+      }
+      100% {
+        transform: translate3d(var(--drift, 0), -120vh, 0) scale(1.08);
+        opacity: 0;
+      }
+    }
+
     @keyframes floatGlow {
       0% {
         transform: translate3d(0, 0, 0) scale(1);
@@ -449,6 +637,19 @@
     }
 
     @media (max-width: 768px) {
+      .light-gradient {
+        inset: -22% -28% -18% -28%;
+        animation-duration: 32s;
+      }
+
+      .light-gradient::after {
+        filter: blur(70px);
+      }
+
+      .light-bubble {
+        filter: blur(0.15vmin);
+      }
+
       .projects {
         flex-direction: column;
         align-items: center;
@@ -480,6 +681,11 @@
 </head>
 <body class="dark-mode">
 
+  <div class="light-background">
+    <div class="light-gradient"></div>
+    <div class="light-bubbles"></div>
+  </div>
+
   <canvas id="aurora-canvas"></canvas>
   <canvas id="particle-canvas"></canvas>
   <div class="static-background-layer static-light"></div>
@@ -491,7 +697,7 @@
     <p class="intro">
       Explore additional engineering, design, and creative projects.
     </p>
-    <button class="theme-toggle" type="button">☀️ / 🌙</button>
+    <button class="theme-toggle" type="button">Toggle Theme</button>
   </header>
 
   <section class="project-section">
@@ -611,6 +817,43 @@
 
     applyInitialTheme();
 
+    const bubbleContainer = document.querySelector('.light-bubbles');
+    const bubbleMediaQuery = window.matchMedia('(max-width: 768px)');
+
+    function populateBubbles() {
+      if (!bubbleContainer || staticMode) return;
+      bubbleContainer.innerHTML = '';
+      const isMobile = bubbleMediaQuery.matches;
+      const bubbleTotal = isMobile ? 18 : 36;
+
+      for (let i = 0; i < bubbleTotal; i++) {
+        const bubble = document.createElement('span');
+        bubble.className = 'light-bubble';
+        const size = (isMobile ? 4 : 5) + Math.random() * (isMobile ? 5 : 9);
+        const duration = (isMobile ? 20 : 28) + Math.random() * (isMobile ? 8 : 12);
+        const delay = -Math.random() * duration;
+        const horizontal = Math.random() * 100;
+        const driftRange = isMobile ? 12 : 20;
+        const drift = (Math.random() * driftRange - driftRange / 2).toFixed(2);
+
+        bubble.style.setProperty('--size', `${size}vmin`);
+        bubble.style.setProperty('--duration', `${duration}s`);
+        bubble.style.setProperty('--delay', `${delay}s`);
+        bubble.style.setProperty('--left-offset', `${horizontal}%`);
+        bubble.style.setProperty('--drift', `${drift}vw`);
+        bubbleContainer.appendChild(bubble);
+      }
+    }
+
+    if (bubbleContainer && !staticMode) {
+      populateBubbles();
+      if (typeof bubbleMediaQuery.addEventListener === 'function') {
+        bubbleMediaQuery.addEventListener('change', populateBubbles);
+      } else if (typeof bubbleMediaQuery.addListener === 'function') {
+        bubbleMediaQuery.addListener(populateBubbles);
+      }
+    }
+
     const toggleButton = document.querySelector('.theme-toggle');
     if (toggleButton) {
       toggleButton.addEventListener('click', () => toggleTheme(true));
@@ -661,23 +904,27 @@
 
       document.addEventListener('themechange', (event) => {
         updateThemeStyles(event.detail?.theme);
+        pausedForLight = currentTheme !== 'dark';
+        if (!pausedForLight) {
+          clearedForLight = false;
+        }
       });
 
       const baseConfig = {
         maxDistance: 170,
-        baseSpeed: 0.16,
-        density: 0.00006,
-        size: [1.0, 2.2],
-        maxCount: 110,
-        maxConnections: 5
+        baseSpeed: 0.14,
+        density: 0.000045,
+        size: [0.9, 2.1],
+        maxCount: 95,
+        maxConnections: 4
       };
 
       const mobileConfig = {
         maxDistance: 135,
-        baseSpeed: 0.11,
-        density: 0.000028,
-        size: [0.9, 1.8],
-        maxCount: 60,
+        baseSpeed: 0.1,
+        density: 0.000022,
+        size: [0.8, 1.7],
+        maxCount: 45,
         maxConnections: 3
       };
 
@@ -686,6 +933,8 @@
       let dpr = window.devicePixelRatio || 1;
       let currentConfig = { ...baseConfig };
       let connectionCounts = new Uint8Array(0);
+      let pausedForLight = currentTheme !== 'dark';
+      let clearedForLight = pausedForLight;
 
       function updateConfig() {
         currentConfig = mobileQuery.matches ? { ...mobileConfig } : { ...baseConfig };
@@ -821,6 +1070,16 @@
         lastTimestamp = timestamp;
         const deltaMultiplier = deltaTime / (1000 / 60);
 
+        if (pausedForLight) {
+          if (!clearedForLight) {
+            ctx.clearRect(0, 0, width, height);
+            clearedForLight = true;
+          }
+          requestAnimationFrame(animate);
+          return;
+        }
+
+        clearedForLight = false;
         ctx.clearRect(0, 0, width, height);
         connectionCounts.fill(0);
         particles.forEach((particle) => {


### PR DESCRIPTION
## Summary
- implement a warm animated gradient and bubble background for light mode while preserving the starfield for dark mode
- refresh button styling across both pages and remove emoji while keeping theme persistence in local storage
- optimize particle rendering by reducing density and pausing the starfield when light mode is active

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dea46117c4832b91e76be6156d0855