### PR TITLE
Add animated starfield background to dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,6 +298,25 @@
       outline: none;
     }
 
+    #particle-canvas {
+      display: none;
+      position: fixed;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    body.dark #particle-canvas {
+      display: block;
+    }
+
+    header, main, footer, section, .video-modal {
+      position: relative;
+      z-index: 1;
+    }
+
     @media (max-width: 768px) {
       header {
         padding-top: 2.5rem;
@@ -317,6 +336,8 @@
 </head>
 
 <body class="dark">
+
+<canvas id="particle-canvas" aria-hidden="true"></canvas>
 
 <header>
   <button class="theme-toggle" type="button">Toggle Theme</button>
@@ -424,6 +445,8 @@
     if (save) {
       localStorage.setItem(themeStorageKey, theme);
     }
+
+    document.dispatchEvent(new CustomEvent('themechange', { detail: { theme } }));
   }
 
   function getPreferredTheme() {
@@ -466,6 +489,22 @@
     document.getElementById('video-frame').src = '';
     document.getElementById('video-modal').style.display = 'none';
   }
+</script>
+
+<script src="starfield.js"></script>
+<script>
+  (function () {
+    const isDark = document.body.classList.contains('dark');
+    if (isDark) {
+      StarfieldBackground.init({ theme: 'dark', heroSelector: 'header' });
+    }
+
+    document.addEventListener('themechange', function (e) {
+      if (e.detail.theme === 'dark' && !window._starfield) {
+        window._starfield = StarfieldBackground.init({ theme: 'dark', heroSelector: 'header' });
+      }
+    });
+  })();
 </script>
 
 </body>

--- a/seemore.html
+++ b/seemore.html
@@ -251,6 +251,25 @@
       }
     }
 
+    #particle-canvas {
+      display: none;
+      position: fixed;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    body.dark #particle-canvas {
+      display: block;
+    }
+
+    header, main, footer, section, .video-modal, .see-more {
+      position: relative;
+      z-index: 1;
+    }
+
     .play-overlay {
       position: absolute;
       inset: 0;
@@ -293,6 +312,8 @@
   </style>
 </head>
 <body class="dark">
+<canvas id="particle-canvas" aria-hidden="true"></canvas>
+
   <header>
     <button class="theme-toggle" type="button">Toggle Theme</button>
     <h1>More Projects</h1>
@@ -426,6 +447,8 @@
       if (save) {
         localStorage.setItem(themeStorageKey, theme);
       }
+
+      document.dispatchEvent(new CustomEvent('themechange', { detail: { theme } }));
     }
 
     function getPreferredTheme() {
@@ -469,7 +492,22 @@
       document.getElementById('video-modal').style.display = 'none';
     }
 
-    document.getElementById('current-year').textContent = new Date().getFullYear();
+  </script>
+
+  <script src="starfield.js"></script>
+  <script>
+    (function () {
+      const isDark = document.body.classList.contains('dark');
+      if (isDark) {
+        StarfieldBackground.init({ theme: 'dark', heroSelector: 'header' });
+      }
+
+      document.addEventListener('themechange', function (e) {
+        if (e.detail.theme === 'dark' && !window._starfield) {
+          window._starfield = StarfieldBackground.init({ theme: 'dark', heroSelector: 'header' });
+        }
+      });
+    })();
   </script>
 </body>
 </html>

--- a/starfield.js
+++ b/starfield.js
@@ -44,7 +44,7 @@
     }
 
     detectTheme() {
-      return document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+      return document.body.classList.contains('dark') ? 'dark' : 'light';
     }
 
     setTheme(theme) {
@@ -105,8 +105,8 @@
     }
 
     populateStars() {
-      const density = this.width > 1200 ? 0.25 : 0.6;
-      const target = clamp(Math.floor(this.width * density), 60, 600);
+      const density = this.width > 1200 ? 0.06 : 0.09;
+      const target = clamp(Math.floor(this.width * density), 40, 100);
       this.stars = new Array(target).fill(null).map(() => this.createStar());
     }
 
@@ -119,7 +119,7 @@
         vx: Math.cos(angle) * baseSpeed,
         vy: Math.sin(angle) * baseSpeed * 0.6,
         size: 0.8 + Math.random() * 1.4,
-        twinkleSpeed: 0.004 + Math.random() * 0.012,
+        twinkleSpeed: 0.002 + Math.random() * 0.005,
         twinklePhase: Math.random() * Math.PI * 2
       };
     }


### PR DESCRIPTION
## Summary
This PR adds an animated particle-based starfield background that displays when the site is in dark mode. The starfield is implemented as a canvas-based animation that renders behind all page content and responds to theme changes.

## Key Changes
- **Canvas Setup**: Added `#particle-canvas` element to both `index.html` and `seemore.html` with fixed positioning, full viewport coverage, and appropriate z-index layering
- **CSS Styling**: 
  - Canvas is hidden by default and only displays when `body.dark` class is present
  - Updated z-index stacking to ensure canvas renders behind content (z-index: 0) while headers, main content, and modals render on top (z-index: 1)
- **Theme Integration**: 
  - Modified `setTheme()` to dispatch a custom `themechange` event when theme changes
  - Added event listener to initialize starfield when switching to dark mode
- **Starfield Configuration**:
  - Fixed theme detection to check for `dark` class instead of `dark-mode`
  - Adjusted star density from 0.25/0.6 to 0.06/0.09 for a more subtle effect
  - Reduced star count range from 60-600 to 40-100
  - Slowed down twinkling animation (twinkleSpeed reduced from 0.004-0.016 to 0.002-0.007)
- **Script Loading**: Added `starfield.js` script reference and initialization logic to both HTML files

## Implementation Details
- The starfield only initializes when the page loads in dark mode or when the user switches to dark mode
- Uses a custom event system to communicate theme changes between the theme toggle and starfield initialization
- Canvas is marked with `aria-hidden="true"` since it's purely decorative
- Star animation is performance-optimized with reduced particle counts and slower animation speeds compared to the original configuration

https://claude.ai/code/session_01JcJbdCuM5WuUYZ4r7WBRS5